### PR TITLE
ClusterIP 타입 실습 - 네임스페이스가 다른 경우

### DIFF
--- a/src/fastcampus/kubenetes/Part3/ch04/delivery/Dockerfile
+++ b/src/fastcampus/kubenetes/Part3/ch04/delivery/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18.16.1-alpine
+
+USER root
+
+RUN apk add --update curl && rm -rf /var/cache/apk/*
+
+COPY . .
+
+EXPOSE 8080
+
+CMD [ "node", "index.js" ]

--- a/src/fastcampus/kubenetes/Part3/ch04/delivery/deployment.yaml
+++ b/src/fastcampus/kubenetes/Part3/ch04/delivery/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: delivery
+  labels:
+    service: delivery
+    project: snackbar
+  namespace: hyunsu
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      service: delivery
+  template:
+    metadata:
+      name: delivery
+      labels:
+        service: delivery
+        project: snackbar
+      namespace: hyunsu
+    spec:
+      containers:
+        - name: delivery
+          image: dlgustn555/delivery:1.0.0
+          ports:
+            - containerPort: 8080
+          resources: {}

--- a/src/fastcampus/kubenetes/Part3/ch04/delivery/index.js
+++ b/src/fastcampus/kubenetes/Part3/ch04/delivery/index.js
@@ -1,0 +1,12 @@
+const http = require("http");
+
+const server = http.createServer((_, res) => {
+  res.statusCode = 200;
+  res.end(JSON.stringify("Delivery Server"));
+});
+
+const PORT = 8080;
+
+server.listen(PORT, () => {
+  console.log(`Delivery Server Is Running ON ${PORT}.`);
+});

--- a/src/fastcampus/kubenetes/Part3/ch04/delivery/service.yaml
+++ b/src/fastcampus/kubenetes/Part3/ch04/delivery/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: delivery
+  labels:
+    service: delivery
+    project: snackbar
+  namespace: hyunsu
+spec:
+  type: ClusterIP
+  selector:
+    service: delivery
+  ports:
+    - port: 80
+      targetPort: 8080


### PR DESCRIPTION
#14 

### 모든 네임스페이스에서 project=snackbar 레이블을 가진 모든 리소스 조회
- kubectl get all -l project=snackbar --all-namespaces

### 모든 네임스페이스에서 project=snackbar 레이블을 가진 Service Endpoints 조회
- kubectl get endpoints -l project=snackbar --all-namespaces

### 다른 네임스페이스에 있는 서비스를 도메인 이름으로 호출
- kubectl exex 파드명 -n 네임스페이스명 -- curl -s 서비스명.네임스페이스

### 모든 네임스페이스에서 project=snackbar 레이블을 가진 모든 리소스 제거
- kubectl delete all -l proejct=snackbar --all-namespaces


![image](https://github.com/dlgustn555/nextjs-playground/assets/15243588/dadadc00-9ca6-46f2-b67a-b16ed41a6a37)
![image](https://github.com/dlgustn555/nextjs-playground/assets/15243588/c3ada053-e1f3-4de1-a7c0-c34bdb3cab0b)


